### PR TITLE
Impoved responsiveness of RecipeViewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "@material-ui/icons": "3.0.1",
     "axios": "0.18.0",
     "base64-img": "1.0.4",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
+    "react": "16.8.4",
+    "react-dom": "16.8.4",
     "react-router-dom": "4.3.1",
     "react-scripts": "2.1.2",
     "standard": "12.0.1"

--- a/src/components/recipe/view/IngredientTypography.js
+++ b/src/components/recipe/view/IngredientTypography.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import { unstable_useMediaQuery as useMediaQuery } from '@material-ui/core/useMediaQuery'
+
+import { Typography } from '@material-ui/core'
+
+const styles = theme => ({
+})
+
+function IngredientTypography (props) {
+  const matches = useMediaQuery('(min-width:1000px)')
+  return (
+    <Typography className={props.classes.ingredient} display='inline' variant='h6' color='textSecondary' noWrap={matches} paragraph>
+      {props.children}
+    </Typography>
+  )
+}
+
+IngredientTypography.propTypes = {
+  classes: PropTypes.object.isRequired,
+  ingredient: PropTypes.object.isRequired
+}
+
+export default withStyles(styles)(IngredientTypography)

--- a/src/components/recipe/view/IngredientsAndInstructions.js
+++ b/src/components/recipe/view/IngredientsAndInstructions.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import { unstable_useMediaQuery as useMediaQuery } from '@material-ui/core/useMediaQuery'
+
+import { Grid, Typography, withTheme } from '@material-ui/core'
+import IngredientTypography from './IngredientTypography'
+
+const styles = theme => ({
+})
+
+function IngredientsAndInstructions (props) {
+  const matches = useMediaQuery(props.theme.breakpoints.up('md'))
+
+  // Split the string on empty lines
+  const instructionArray = props.instructions.split('\r\n\r\n')
+  return (
+    <Grid container item direction='row' spacing='40' wrap={matches ? 'nowrap' : 'wrap'}>
+      <Grid item>
+        <Typography display='inline' variant='h6' color='textPrimary' paragraph>
+          Ingredients:
+        </Typography>
+        {props.ingredients.map((ingredient) => (
+          <IngredientTypography>
+            {ingredient.quantity !== 0 && ingredient.quantity} {ingredient.unit} {ingredient.ingredient}
+          </IngredientTypography>
+        ))
+        }
+      </Grid>
+      <Grid item>
+        <Typography display='inline' variant='h6' color='textPrimary' paragraph>
+          Instructions:
+        </Typography>
+        {instructionArray.map((instruction, index) => (
+          <Typography display='inline' variant='h6' color='textSecondary' paragraph>
+            {index + 1}. {instruction}
+          </Typography>
+        ))
+        }
+      </Grid>
+    </Grid>
+  )
+}
+
+IngredientsAndInstructions.propTypes = {
+  classes: PropTypes.object.isRequired,
+  ingredients: PropTypes.array.isRequired,
+  instructions: PropTypes.string.isRequired
+}
+
+export default withTheme()(withStyles(styles)(IngredientsAndInstructions))

--- a/src/components/recipe/view/RecipeDisplay.js
+++ b/src/components/recipe/view/RecipeDisplay.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 
 import { Paper, Typography, Button, Grid } from '@material-ui/core'
+import IngredientsAndInstructions from './IngredientsAndInstructions'
 
 const styles = theme => ({
   paper: {
@@ -49,41 +50,6 @@ class RecipeDisplay extends React.Component {
     return sourceText
   }
 
-  renderIngredients () {
-    return (
-      <React.Fragment>
-        <Typography display='inline' variant='h6' color='textPrimary' paragraph>
-          Ingredients:
-        </Typography>
-        {this.props.recipe.ingredients.map((ingredient) => (
-          <Typography display='inline' variant='h6' color='textSecondary' paragraph>
-            {ingredient.quantity !== 0 && ingredient.quantity} {ingredient.unit} {ingredient.ingredient}
-          </Typography>
-        ))
-        }
-      </React.Fragment>
-    )
-  }
-
-  renderInstructions () {
-    // Split the string on empty lines
-    const instructionArray = this.props.recipe.instructions.split('\r\n\r\n')
-
-    return (
-      <React.Fragment>
-        <Typography display='inline' variant='h6' color='textPrimary' paragraph>
-          Instructions:
-        </Typography>
-        {instructionArray.map((instruction, index) => (
-          <Typography display='inline' variant='h6' color='textSecondary' paragraph>
-            {index + 1}. {instruction}
-          </Typography>
-        ))
-        }
-      </React.Fragment>
-    )
-  }
-
   render () {
     const recipeTitle = (
       <Typography component='h1' variant='h2' align='center' color='textPrimary' gutterBottom>
@@ -101,14 +67,7 @@ class RecipeDisplay extends React.Component {
           <Grid item>
             {this.renderSource(this.props.recipe.sourceName, this.props.recipe.sourceUrl)}
           </Grid>
-          <Grid container item direction='row' spacing='40'>
-            <Grid item>
-              {this.renderIngredients()}
-            </Grid>
-            <Grid item>
-              {this.renderInstructions()}
-            </Grid>
-          </Grid>
+          <IngredientsAndInstructions ingredients={this.props.recipe.ingredients} instructions={this.props.recipe.instructions} />
           <Grid container item direction='row' spacing='8' justify='flex-end'>
             <Grid item>
               <Button className={this.props.classes.button} variant='contained' size='small' color='primary' onClick={this.props.handleEditRecipe}>


### PR DESCRIPTION
Add: Ingredients don't wrap for large window sizes
Add: Instructions don't wrap below ingredients for large window sizes
Bump: react version to 16.8.4 for hooks
Add: split off part of RecipeDisplay handling ingredients and instructions